### PR TITLE
Find linters by matched syntax

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -111,12 +111,12 @@ function lint.get_linter_for_doc(doc)
     end
     if linter.syntax ~= nil then
       local header = doc:get_text(1, 1, doc:position_offset(1, 1, 128))
-      local syn = syntax.get(doc.filename or "", header)
+      local syn = syntax.get(doc.filename, header)
       for i = #linter.syntax, 1, -1 do
-         local s = linter.syntax[i]
-         if syn.name == s then
-           return linter, name
-         end
+        local s = linter.syntax[i]
+        if syn.name == s then
+          return linter, name
+        end
       end
     end
   end
@@ -877,7 +877,6 @@ end
 
 
 lint.filename = {}
-lint.syntax = {}
 lint.args = {}
 
 

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,7 @@ local common = require "core.common"
 local config = require "core.config"
 local style = require "core.style"
 local keymap = require "core.keymap"
+local syntax = require "core.syntax"
 
 local Doc = require "core.doc"
 local DocView = require "core.docview"
@@ -107,6 +108,16 @@ function lint.get_linter_for_doc(doc)
   for name, linter in pairs(lint.index) do
     if common.match_pattern(file, linter.filename) then
       return linter, name
+    end
+    if linter.syntax ~= nil then
+      local header = doc:get_text(1, 1, doc:position_offset(1, 1, 128))
+      local syn = syntax.get(doc.filename or "", header)
+      for i = #linter.syntax, 1, -1 do
+         local s = linter.syntax[i]
+         if syn.name == s then
+           return linter, name
+         end
+      end
     end
   end
 end
@@ -866,6 +877,7 @@ end
 
 
 lint.filename = {}
+lint.syntax = {}
 lint.args = {}
 
 


### PR DESCRIPTION
Shell scripts and other file types may not have file extensions. This means lint+ cannot load the required linters.

My proposed changes adds the ability to load linters based on the files syntax. 

To ensure some control I have introduced a syntax table to the linter API. The syntax table will list all syntax names associated with the linter. 

Please bear in mind I'm not a Lua programmer. I more than happy to make adjustments on your advice.