### PR TITLE
Add `Minimap` highlights support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,9 @@
       "description": "An improved linting plugin.",
       "version": "0.3",
       "mod_version": "3",
+      "dependencies": {
+        "minimap": { "optional": true }
+      },
       "tags": [
         "linter"
       ]


### PR DESCRIPTION
This works with the WIP `minimap` plugin PR lite-xl/lite-xl-plugins#284.

![image](https://github.com/liquidev/lintplus/assets/2798487/49759b01-e71e-4558-a84b-abe701b47c91)

Should this be a config option?
If so, name suggestions are welcome.