### PR TITLE
Python linter: allow using config.lint.flake8_args

### DIFF
--- a/linters/luacheck.lua
+++ b/linters/luacheck.lua
@@ -51,7 +51,7 @@ local function command(filename)
 end
 
 lintplus.add("luacheck") {
-  filename = "%.lua$",
+  filename = { "%.lua$", "%.rockspec$" },
   procedure = {
     command = command,
     interpreter = lintplus.interpreter {

--- a/linters/moonscript.lua
+++ b/linters/moonscript.lua
@@ -1,0 +1,53 @@
+-- MoonScript plugin for lint+
+
+--- CONFIG ---
+
+-- config.lint.moonscript_args: table[string]
+--   passes the specified arguments to moonscript
+
+--- IMPLEMENTATION ---
+
+local core = require "core"
+local lintplus = require "plugins.lintplus"
+
+local line_processed = false
+local fatal = nil
+
+local function interpreter(filename, line, _context)
+      return function ()
+        if line_processed then
+          line_processed = false
+          return nil
+        end
+        if fatal then
+          local line_num = line:match("^.*%[(%d+)%] >>") or "1"
+          line_processed = true
+          fatal = nil
+          return filename, tonumber(line_num), 1, "error", "Failed to parse"
+        end
+        local line_num, message = line:match("^line (%d+): (.+)$")
+        fatal = line:match("^Failed to parse:$")
+        if fatal then
+          return nil
+        end
+        if line_num then
+          line_processed = true
+          return filename, tonumber(line_num), 1, "warning", message
+        end
+        return nil
+      end
+end
+
+lintplus.add("moonscript") {
+  filename = "%.moon$",
+  procedure = {
+    command = lintplus.args_command(
+      { "moonc",
+        lintplus.args,
+        "--lint",
+        lintplus.filename },
+      "moonscript_args"
+    ),
+    interpreter = interpreter
+  },
+}

--- a/linters/python.lua
+++ b/linters/python.lua
@@ -3,8 +3,9 @@
  lintplus.add("flake8") {
    filename = "%.py$",
    procedure = {
-     command = lintplus.command(
+     command = lintplus.args_command(
        { "flake8",
+         lintplus.args,
          lintplus.filename },
          "flake8_args"
      ),

--- a/linters/shellcheck.lua
+++ b/linters/shellcheck.lua
@@ -15,7 +15,7 @@
 local lintplus = require "plugins.lintplus"
 
 lintplus.add("shellcheck") {
-  filename = "%.sh$",
+  filename = {"%.sh$", "APKBUILD$"},
   syntax = {
     "Shell script",
     "shellscript",


### PR DESCRIPTION
+ linters/moonscript.lua: MoonScript language support
+ Python linter: allow using config.lint.flake8_args
+ luacheck and Shellcheck: add more relevant file extensions